### PR TITLE
[Feat] smtp로 아이디 비밀벚호 찾기를 구현하다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ out/
 ## db ##
 nbe2_2_dev.mv.db
 nbe2_2_dev.trace.db
+
+## secret ##
+application-secret.yml

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,9 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    //SMTP
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/devcoursed/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/example/devcoursed/domain/member/member/controller/MemberController.java
@@ -1,9 +1,13 @@
 package com.example.devcoursed.domain.member.member.controller;
 
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
@@ -27,6 +31,7 @@ import java.util.stream.Collectors;
 public class MemberController {
     private final MemberService memberService;
     private final ResourceLoader resourceLoader;
+    private final JavaMailSender mailSender;
 
     //회원가입
     @PostMapping("/register")
@@ -140,4 +145,52 @@ public class MemberController {
         Resource file = resourceLoader.getResource("file:upload/" + filename);
         return ResponseEntity.ok(file);
     }
+
+    //아이디 찾기
+    @GetMapping("/findId")
+    public ResponseEntity<String> findId(@RequestParam String email) {
+        String loginId = memberService.findByEmail(email);
+
+        return ResponseEntity.ok(loginId);
+    }
+
+    //비밀번호 찾기
+    @PostMapping("/findPW")
+    public ResponseEntity<String> findPw(@RequestBody MemberDTO.FindPWRequestDto request) {
+        String templatePassword = memberService.setTemplatePassword(request.getLoginId(), request.getEmail());
+
+        String title = "데브코스 팀2 아이디/비밀번호 찾기 인증 이메일 입니다.";
+        String from= "seodo1e1205@gmail.com";
+        String to = request.getEmail();
+        String content =
+                System.getProperty("line.separator")+
+                        System.getProperty("line.separator")+
+                        "임시 비밀번호로 로그인 후 꼭 새로운 비밀번호로 설정해주시기 바랍니다."
+                        +System.getProperty("line.separator")+
+                        System.getProperty("line.separator")+
+                        "임시비밀번호는 " +templatePassword+ " 입니다. "
+                        +System.getProperty("line.separator");
+
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper messageHelper = new MimeMessageHelper(message, true, "UTF-8");
+
+            messageHelper.setFrom(from);
+            messageHelper.setTo(to);
+            messageHelper.setSubject(title);
+            messageHelper.setText(content);
+
+            mailSender.send(message);
+
+        } catch (Exception e) {
+            log.debug(e);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("임시 비밀번호 전송을 실패하였습니다");
+        }
+        return ResponseEntity.ok("임시 비밀번호를 이메일로 전송했습니다");
+
+
+    }
+
+
+
 }

--- a/src/main/java/com/example/devcoursed/domain/member/member/dto/MemberDTO.java
+++ b/src/main/java/com/example/devcoursed/domain/member/member/dto/MemberDTO.java
@@ -2,6 +2,7 @@ package com.example.devcoursed.domain.member.member.dto;
 
 import com.example.devcoursed.domain.member.member.entity.Member;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 

--- a/src/main/java/com/example/devcoursed/domain/member/member/dto/MemberDTO.java
+++ b/src/main/java/com/example/devcoursed/domain/member/member/dto/MemberDTO.java
@@ -13,6 +13,7 @@ public class MemberDTO {
     @Data
     public static class Create {
         private String loginId;
+        private String email;
         private String pw;
         private String name;
         @JsonProperty("mImage")
@@ -22,6 +23,7 @@ public class MemberDTO {
             return Member.builder()
                     .loginId(loginId)
                     .pw(pw)
+                    .email(email)
                     .name(name)
                     .mImage(mImage)
                     .build();
@@ -95,6 +97,7 @@ public class MemberDTO {
     public static class Response {
         private long id;
         private String loginId;
+        private String email;
         private String pw;
         private String name;
         private String mImage;
@@ -109,6 +112,7 @@ public class MemberDTO {
             this.mImage = member.getMImage();
             this.createdAt = member.getCreatedAt();
             this.modifiedAt = member.getModifiedAt();
+            this.email = member.getEmail();
         }
 
 
@@ -129,6 +133,13 @@ public class MemberDTO {
         public logoutResponseDto(String message) {
             this.message = message;
         }
+    }
+
+    @Data
+    public static class FindPWRequestDto {
+
+        private String loginId;
+        private String email;
     }
 
 //    @Data

--- a/src/main/java/com/example/devcoursed/domain/member/member/entity/Member.java
+++ b/src/main/java/com/example/devcoursed/domain/member/member/entity/Member.java
@@ -32,6 +32,7 @@ public class Member {
 
     private String pw;
     private String name;
+    private String email;
 
     private String mImage;
     @Column(columnDefinition = "TEXT")
@@ -53,11 +54,12 @@ public class Member {
 
 
     @Builder
-    public Member(String loginId, String pw, String name, String mImage) {
+    public Member(String loginId, String pw, String name, String mImage , String email) {
         this.loginId = loginId;
         this.pw = pw;
         this.name = name;
         this.mImage = mImage;
+        this.email = email;
     }
 
     public void changeLoginId(String loginId) {

--- a/src/main/java/com/example/devcoursed/domain/member/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/devcoursed/domain/member/member/repository/MemberRepository.java
@@ -12,4 +12,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> , MemberRe
     Optional<Member> findByLoginId(String loginId);
 
     Optional<Member> findByRefreshToken(String refreshToken);
+
+    Optional<Member> findByEmail(String email);
+    Optional<Member> findByLoginIdAndEmail(String loginId , String email);
 }

--- a/src/main/java/com/example/devcoursed/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/example/devcoursed/domain/member/member/service/MemberService.java
@@ -4,10 +4,11 @@ import com.example.devcoursed.domain.member.member.exception.MemberException;
 import com.example.devcoursed.domain.member.member.dto.MemberDTO;
 import com.example.devcoursed.domain.member.member.entity.Member;
 import com.example.devcoursed.domain.member.member.repository.MemberRepository;
-import com.example.devcoursed.domain.member.member.repository.MemberRepositoryImpl;
 import com.example.devcoursed.global.util.JwtUtil;
+import com.example.devcoursed.global.util.PasswordUtil;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
+import jdk.jshell.execution.Util;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,8 +21,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -227,4 +226,20 @@ public class MemberService {
     }
 
 
+    public String findByEmail(String email) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(() -> MemberException.MEMBER_NOT_FOUND.getMemberTaskException());
+        return member.getLoginId();
+
+    }
+
+    @Transactional
+    public String setTemplatePassword(String loginId, String email) {
+        Member member = memberRepository.findByLoginIdAndEmail(loginId, email).orElseThrow(() -> MemberException.MEMBER_NOT_FOUND.getMemberTaskException());
+        String templatePassword = PasswordUtil.generateTempPassword();
+        member.changePw(passwordEncoder.encode(templatePassword));
+        memberRepository.save(member);
+
+        return templatePassword;
+
+    }
 }

--- a/src/main/java/com/example/devcoursed/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/example/devcoursed/domain/member/member/service/MemberService.java
@@ -5,8 +5,10 @@ import com.example.devcoursed.domain.member.member.dto.MemberDTO;
 import com.example.devcoursed.domain.member.member.entity.Member;
 import com.example.devcoursed.domain.member.member.repository.MemberRepository;
 import com.example.devcoursed.global.util.JwtUtil;
+import com.example.devcoursed.global.util.PasswordUtil;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
+import jdk.jshell.execution.Util;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -224,4 +226,20 @@ public class MemberService {
     }
 
 
+    public String findByEmail(String email) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(() -> MemberException.MEMBER_NOT_FOUND.getMemberTaskException());
+        return member.getLoginId();
+
+    }
+
+    @Transactional
+    public String setTemplatePassword(String loginId, String email) {
+        Member member = memberRepository.findByLoginIdAndEmail(loginId, email).orElseThrow(() -> MemberException.MEMBER_NOT_FOUND.getMemberTaskException());
+        String templatePassword = PasswordUtil.generateTempPassword();
+        member.changePw(passwordEncoder.encode(templatePassword));
+        memberRepository.save(member);
+
+        return templatePassword;
+
+    }
 }

--- a/src/main/java/com/example/devcoursed/global/iniData/NotProd.java
+++ b/src/main/java/com/example/devcoursed/global/iniData/NotProd.java
@@ -52,7 +52,15 @@ public class NotProd {
         MemberDTO.Create requestDto = new MemberDTO.Create();
         requestDto.setLoginId("admin");
         requestDto.setPw("1234");
+        requestDto.setEmail("admin@naver.com");
         requestDto.setName("운영자");
+        memberService.create(requestDto);
+
+        MemberDTO.Create requestDto2 = new MemberDTO.Create();
+        requestDto.setLoginId("test123");
+        requestDto.setPw("1234");
+        requestDto.setEmail("zmdk1205@naver.com");
+        requestDto.setName("서상원");
         memberService.create(requestDto);
 
         //member 50명 생성
@@ -60,6 +68,7 @@ public class NotProd {
             MemberDTO.Create createDto = new MemberDTO.Create();
             createDto.setLoginId("abc" + i);
             createDto.setPw("1234");
+            createDto.setEmail("abc"+i+"@naver.com");
             createDto.setName("회원" + i);
 
             memberService.create(createDto);

--- a/src/main/java/com/example/devcoursed/global/iniData/NotProd.java
+++ b/src/main/java/com/example/devcoursed/global/iniData/NotProd.java
@@ -49,7 +49,15 @@ public class NotProd {
         MemberDTO.CreateRequestDto requestDto = new MemberDTO.CreateRequestDto();
         requestDto.setLoginId("admin");
         requestDto.setPw("1234");
+        requestDto.setEmail("admin@naver.com");
         requestDto.setName("운영자");
+        memberService.create(requestDto);
+
+        MemberDTO.Create requestDto2 = new MemberDTO.Create();
+        requestDto.setLoginId("test123");
+        requestDto.setPw("1234");
+        requestDto.setEmail("zmdk1205@naver.com");
+        requestDto.setName("서상원");
         memberService.create(requestDto);
 
         //member 50명 생성
@@ -57,6 +65,7 @@ public class NotProd {
             MemberDTO.CreateRequestDto createDto = new MemberDTO.CreateRequestDto();
             createDto.setLoginId("abc" + i);
             createDto.setPw("1234");
+            createDto.setEmail("abc"+i+"@naver.com");
             createDto.setName("회원" + i);
 
             memberService.create(createDto);

--- a/src/main/java/com/example/devcoursed/global/iniData/NotProd.java
+++ b/src/main/java/com/example/devcoursed/global/iniData/NotProd.java
@@ -53,7 +53,7 @@ public class NotProd {
         requestDto.setName("운영자");
         memberService.create(requestDto);
 
-        MemberDTO.Create requestDto2 = new MemberDTO.Create();
+        MemberDTO.CreateRequestDto requestDto2 = new MemberDTO.CreateRequestDto();
         requestDto.setLoginId("test123");
         requestDto.setPw("1234");
         requestDto.setEmail("zmdk1205@naver.com");

--- a/src/main/java/com/example/devcoursed/global/security/ApiSecurityConfig.java
+++ b/src/main/java/com/example/devcoursed/global/security/ApiSecurityConfig.java
@@ -31,7 +31,7 @@ public class ApiSecurityConfig {
                         .hasRole("ADMIN")
 
                         // 인증 없이 접근 가능한 엔드포인트
-                        .requestMatchers("/api/v1/members/login", "/api/v1/members/register","api/**","/api/v1/members/refreshAccessToken").permitAll()
+                        .requestMatchers("/api/v1/members/login", "/api/v1/members/register","/api/**","/api/v1/members/refreshAccessToken").permitAll()
                         .anyRequest().authenticated()
 
                 )

--- a/src/main/java/com/example/devcoursed/global/util/PasswordUtil.java
+++ b/src/main/java/com/example/devcoursed/global/util/PasswordUtil.java
@@ -1,0 +1,18 @@
+package com.example.devcoursed.global.util;
+
+import java.security.SecureRandom;
+
+public class PasswordUtil {
+
+    private static final String CHAR_SET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
+
+    public static String generateTempPassword() {
+        SecureRandom random = new SecureRandom();
+        StringBuilder tempPassword = new StringBuilder(6);
+        for (int i = 0; i < 6; i++) {
+            int index = random.nextInt(CHAR_SET.length());
+            tempPassword.append(CHAR_SET.charAt(index));
+        }
+        return tempPassword.toString();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,10 +3,11 @@ spring:
     host: smtp.gmail.com
     port: 587
     username: seodo1e1205@gmail.com
-    password: endlfdl156@
+    password: nnjd usla bvhe crsd
     properties:
       mail.smtp.auth: true
       mail.smtp.starttls.enable: true
+      debug : true
 
   profiles:
     active: dev
@@ -30,7 +31,7 @@ spring:
 
 logging:
   level:
-    com.example.com.example.devcoursed: DEBUG
+    com.example.devcoursed: DEBUG
     org.hibernate.SQL: DEBUG
     org.hibernate.orm.jdbc.bind: TRACE
     org.hibernate.orm.jdbc.extract: TRACE

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,16 +1,7 @@
 spring:
-  mail:
-    host: smtp.gmail.com
-    port: 587
-    username: seodo1e1205@gmail.com
-    password: nnjd usla bvhe crsd
-    properties:
-      mail.smtp.auth: true
-      mail.smtp.starttls.enable: true
-      debug : true
-
   profiles:
     active: dev
+    include : secret
   threads:
     virtual:
       enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,13 @@
 spring:
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: seodo1e1205@gmail.com
+    password: endlfdl156@
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
+
   profiles:
     active: dev
   threads:


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 🚨 동기화된 develop 브랜치임을 확인했나요?

### 작업 내용
- 아이디찾기 : 이메일로 회원찾은 후 아이디 값 리턴 , 비밀번호 찾기 : 회원가입시 등록한 이메일로 임시 비밀번호 전송 

### 스크린샷 (생략 가능)
- 
![스크린샷 2024-10-04 오후 5 16 29](https://github.com/user-attachments/assets/36fd79d9-6bb7-457e-a2b4-083729109c55)


### To Reviewer (리뷰어가 집중적으로 봐야할 것)

- smtp 의존성 추가 